### PR TITLE
卒業を表すためのカラムを追加

### DIFF
--- a/db/migrate/20150416133521_add_graduated_to_maids.rb
+++ b/db/migrate/20150416133521_add_graduated_to_maids.rb
@@ -1,0 +1,5 @@
+class AddGraduatedToMaids < ActiveRecord::Migration
+  def change
+    add_column :maids, :graduated, :integer, :null => false, :default => 0
+  end
+end

--- a/db/migrate/20150416133521_add_graduated_to_maids.rb
+++ b/db/migrate/20150416133521_add_graduated_to_maids.rb
@@ -1,5 +1,5 @@
 class AddGraduatedToMaids < ActiveRecord::Migration
   def change
-    add_column :maids, :graduated, :integer, :null => false, :default => 0
+    add_column :maids, :graduated, :boolean, :null => false, :default => false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150415135733) do
+ActiveRecord::Schema.define(version: 20150416133521) do
 
   create_table "maids", force: :cascade do |t|
-    t.string   "name",       null: false
+    t.string   "name",                   null: false
     t.string   "floor"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer  "number",     null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
+    t.integer  "number",                 null: false
+    t.integer  "graduated",  default: 0, null: false
   end
 
   add_index "maids", ["number"], name: "index_maids_on_number", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,12 +14,12 @@
 ActiveRecord::Schema.define(version: 20150416133521) do
 
   create_table "maids", force: :cascade do |t|
-    t.string   "name",                   null: false
+    t.string   "name",                       null: false
     t.string   "floor"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
-    t.integer  "number",                 null: false
-    t.integer  "graduated",  default: 0, null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.integer  "number",                     null: false
+    t.boolean  "graduated",  default: false, null: false
   end
 
   add_index "maids", ["number"], name: "index_maids_on_number", unique: true


### PR DESCRIPTION
#7 @gaoch 
卒業したメイドさんに対応するためのカラムを追加しました
`maid`テーブルに`graduated`カラムを追加しています．
現役のメイドさんの場合はこの値が0，卒業してメイドさんの一覧ページに表れなくなった場合にこのフラグを更新して1にします

まだクローラーのほうで更新する実装を行っていません(こっちのほうが優先かと思って先にPRを出しました)

db:migrateしてメイドさんのレコードを確認するとこんな感じになります

![2015-04-16 22 58 41](https://cloud.githubusercontent.com/assets/5152601/7182482/9b3e0420-e48c-11e4-8562-a578694fe70d.png)
