### PR TITLE
ツイートと画像を新しいものを上にくるよう並び替え

### DIFF
--- a/app/crawlers/twitter_crawler.rb
+++ b/app/crawlers/twitter_crawler.rb
@@ -10,7 +10,7 @@ class TwitterCrawler
 
           if tweet.media?
             tweet.media.select{|media| media.class == Twitter::Media::Photo}.each do |photo|
-              Picture.create({tweet_id: created_tweet.id, url: photo.media_url.to_s})
+              Picture.create({tweet_id: created_tweet.id, url: photo.media_url.to_s, published_at: tweet.created_at})
             end
           end
         end

--- a/app/models/maid.rb
+++ b/app/models/maid.rb
@@ -5,12 +5,12 @@ class Maid < ActiveRecord::Base
   has_one :twitter_account
 
   def tweets
-    self.twitter_account.tweets
+    self.twitter_account.tweets.order('published_at DESC')
   end
 
   def pictures
     pictures = []
-    tweets = self.twitter_account.tweets
+    tweets = self.twitter_account.tweets.order('published_at DESC')
     tweets.select{|tweet| tweet.pictures}.map do |tweet|
       tweet.pictures.each{|pic| pictures << pic}
     end

--- a/db/migrate/20150418124944_add_published_at_to_pictures.rb
+++ b/db/migrate/20150418124944_add_published_at_to_pictures.rb
@@ -1,0 +1,10 @@
+class AddPublishedAtToPictures < ActiveRecord::Migration
+  def up
+    add_column :pictures, :published_at, :date
+    change_column :pictures, :published_at, :datetime, {null: false}
+  end
+
+  def down
+    remove_column :pictures, :published_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150415135733) do
+ActiveRecord::Schema.define(version: 20150418124944) do
 
   create_table "maids", force: :cascade do |t|
     t.string   "name",       null: false
@@ -24,10 +24,13 @@ ActiveRecord::Schema.define(version: 20150415135733) do
   add_index "maids", ["number"], name: "index_maids_on_number", unique: true
 
   create_table "pictures", force: :cascade do |t|
-    t.integer  "tweet_id",   null: false
-    t.string   "url",        null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer  "tweet_id",                     null: false
+    t.string   "url",                          null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.boolean  "analyzed",     default: false, null: false
+    t.integer  "kind"
+    t.datetime "published_at",                 null: false
   end
 
   add_index "pictures", ["tweet_id"], name: "index_pictures_on_tweet_id"


### PR DESCRIPTION
#9
@gaoch 
これまで並び順がおかしかったので，新しいものが上にくるように降順に並び替えた
今回は使ってないけども，画像のほうもツイート同様に`published_at`の項目があったほうがいいと思い追加