### PR TITLE
お給仕予定日を表現するモデルを作成

### DIFF
--- a/app/models/serving_day.rb
+++ b/app/models/serving_day.rb
@@ -1,3 +1,6 @@
 class ServingDay < ActiveRecord::Base
+  validates :maid_id, presence: true
+  validates :picture_id, presence: true
+  validates :location, presence: true
 
 end

--- a/app/models/serving_day.rb
+++ b/app/models/serving_day.rb
@@ -6,5 +6,5 @@ class ServingDay < ActiveRecord::Base
   belongs_to :maid
   belongs_to :pictures
 
-  enum location: {undecided: 0, fourth_floor: 1, fifth_floor: 2, seventh_floor: 3}
+  enum location: {undecided: 0, fourth_floor: 4, fifth_floor: 5, sixth_floor: 6, seventh_floor: 7, donki_floor: 10}
 end

--- a/app/models/serving_day.rb
+++ b/app/models/serving_day.rb
@@ -3,4 +3,6 @@ class ServingDay < ActiveRecord::Base
   validates :picture_id, presence: true
   validates :location, presence: true
 
+  belongs_to :maid
+  belongs_to :pictures
 end

--- a/app/models/serving_day.rb
+++ b/app/models/serving_day.rb
@@ -1,0 +1,3 @@
+class ServingDay < ActiveRecord::Base
+
+end

--- a/app/models/serving_day.rb
+++ b/app/models/serving_day.rb
@@ -5,4 +5,6 @@ class ServingDay < ActiveRecord::Base
 
   belongs_to :maid
   belongs_to :pictures
+
+  enum location: {undecided: 0, fourth_floor: 1, fifth_floor: 2, seventh_floor: 3}
 end

--- a/db/migrate/20150421233328_create_serving_days.rb
+++ b/db/migrate/20150421233328_create_serving_days.rb
@@ -1,6 +1,13 @@
 class CreateServingDays < ActiveRecord::Migration
   def change
     create_table :serving_days do |t|
+      t.references :maid, null: false, index: true
+      t.references :picture, null: false, index: true
+      t.date :date
+      t.time :time
+      t.integer :location, default: 0, null: false
+      t.string :miss_analyzed
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20150421233328_create_serving_days.rb
+++ b/db/migrate/20150421233328_create_serving_days.rb
@@ -1,0 +1,6 @@
+class CreateServingDays < ActiveRecord::Migration
+  def change
+    create_table :serving_days do |t|
+    end
+  end
+end

--- a/db/migrate/20150421233328_create_serving_days.rb
+++ b/db/migrate/20150421233328_create_serving_days.rb
@@ -3,11 +3,10 @@ class CreateServingDays < ActiveRecord::Migration
     create_table :serving_days do |t|
       t.references :maid, null: false, index: true
       t.references :picture, null: false, index: true
-      t.date :date
+      t.date :date, null: false
       t.time :start_time
       t.time :end_time
       t.integer :location, default: 0, null: false
-      t.string :miss_analyzed
       t.timestamps null: false
     end
   end

--- a/db/migrate/20150421233328_create_serving_days.rb
+++ b/db/migrate/20150421233328_create_serving_days.rb
@@ -4,7 +4,8 @@ class CreateServingDays < ActiveRecord::Migration
       t.references :maid, null: false, index: true
       t.references :picture, null: false, index: true
       t.date :date
-      t.time :time
+      t.time :start_time
+      t.time :end_time
       t.integer :location, default: 0, null: false
       t.string :miss_analyzed
       t.timestamps null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150418124944) do
+ActiveRecord::Schema.define(version: 20150421233328) do
 
   create_table "maids", force: :cascade do |t|
     t.string   "name",                       null: false
@@ -36,6 +36,20 @@ ActiveRecord::Schema.define(version: 20150418124944) do
 
   add_index "pictures", ["tweet_id"], name: "index_pictures_on_tweet_id"
   add_index "pictures", ["url"], name: "index_pictures_on_url", unique: true
+
+  create_table "serving_days", force: :cascade do |t|
+    t.integer  "maid_id",                   null: false
+    t.integer  "picture_id",                null: false
+    t.date     "date"
+    t.time     "time"
+    t.integer  "location",      default: 0, null: false
+    t.string   "miss_analyzed"
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "serving_days", ["maid_id"], name: "index_serving_days_on_maid_id"
+  add_index "serving_days", ["picture_id"], name: "index_serving_days_on_picture_id"
 
   create_table "tweets", force: :cascade do |t|
     t.integer  "twitter_account_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,8 @@ ActiveRecord::Schema.define(version: 20150421233328) do
     t.integer  "maid_id",                   null: false
     t.integer  "picture_id",                null: false
     t.date     "date"
-    t.time     "time"
+    t.time     "start_time"
+    t.time     "end_time"
     t.integer  "location",      default: 0, null: false
     t.string   "miss_analyzed"
     t.datetime "created_at",                null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,15 +38,14 @@ ActiveRecord::Schema.define(version: 20150421233328) do
   add_index "pictures", ["url"], name: "index_pictures_on_url", unique: true
 
   create_table "serving_days", force: :cascade do |t|
-    t.integer  "maid_id",                   null: false
-    t.integer  "picture_id",                null: false
-    t.date     "date"
+    t.integer  "maid_id",                null: false
+    t.integer  "picture_id",             null: false
+    t.date     "date",                   null: false
     t.time     "start_time"
     t.time     "end_time"
-    t.integer  "location",      default: 0, null: false
-    t.string   "miss_analyzed"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer  "location",   default: 0, null: false
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
   end
 
   add_index "serving_days", ["maid_id"], name: "index_serving_days_on_maid_id"


### PR DESCRIPTION
ref #16
@gaoch 画像から読み取ったお給仕予定日を表現するためのモデルを作成しました．

#16 では`miss_analyzed`という認識に失敗した文字を格納する予定だったカラムを削除しました．理由は以下です

- お給仕予定日を表現しているテーブルなのに，お給仕予定日が入っていない状態(認識に失敗して`date`カラムがnullな状態)に違和感があった
- それだったら`MissAnalyzedWords`のようなカラムを作成して，そちらと紐付けたほうがよいのでは？と思った
- あと画像全てを解析した場合，文字が入っている画像を自動で「お給仕画像」「全く関係ない文字が含まれている画像」を自動で判別するのが厳しいと感じた．
- 下記画像のようにお給仕予定画像とは全く異なる文字を含む画像の文字列が`ServingDays`テーブルに保存されることを防ぎたい

このような理由で当初の予定とは変更しました．今のところパッと`MissAnalyzedWords`をどういった構成にすればいいか思いつかないので，とりあえず読み取りに成功したときに用いるモデルだけをpushしてあるかんじです！

確認お願いします！

![image](https://cloud.githubusercontent.com/assets/5152601/7272959/09d482dc-e92a-11e4-85f3-a531fb5e8540.png)