### PR TITLE
一部のメイドさんのツイートを取得できない問題の改善案

### DIFF
--- a/app/crawlers/twitter_crawler.rb
+++ b/app/crawlers/twitter_crawler.rb
@@ -7,8 +7,8 @@ class TwitterCrawler
     accounts = TwitterAccount.all.select('id, screen_name')
 
     accounts.each do |account|
-      @client.get_recent_tweets(account).each do |tweet|
-        begin
+      begin
+        @client.get_recent_tweets(account).each do |tweet|
           created_tweet = Tweet.create({twitter_account_id: account.id, text: tweet.text, status_id:  tweet.id, published_at: tweet.created_at})
 
           if tweet.media?
@@ -16,10 +16,10 @@ class TwitterCrawler
               Picture.create({tweet_id: created_tweet.id, url: photo.media_url.to_s, published_at: tweet.created_at})
             end
           end
-        rescue => e
-          p e
-          p "failed import #{account.screen_name}'s tweet"
         end
+      rescue => e
+        p e
+        p "failed import #{account.screen_name}'s tweet"
       end
     end
   end

--- a/app/crawlers/twitter_crawler.rb
+++ b/app/crawlers/twitter_crawler.rb
@@ -1,11 +1,14 @@
 class TwitterCrawler
-  def self.import_recent_tweet
+  def initialize
+    @client = TwitterClient.new
+  end
+
+  def import_recent_tweet
     accounts = TwitterAccount.all.select('id, screen_name')
-    client = TwitterClient.new
 
     accounts.each do |account|
-      begin
-        client.get_recent_tweets(account).each do |tweet|
+      @client.get_recent_tweets(account).each do |tweet|
+        begin
           created_tweet = Tweet.create({twitter_account_id: account.id, text: tweet.text, status_id:  tweet.id, published_at: tweet.created_at})
 
           if tweet.media?
@@ -13,10 +16,10 @@ class TwitterCrawler
               Picture.create({tweet_id: created_tweet.id, url: photo.media_url.to_s, published_at: tweet.created_at})
             end
           end
+        rescue => e
+          p e
+          p "failed import #{account.screen_name}'s tweet"
         end
-      rescue => e
-        p e
-        p "failed import #{account.screen_name}'s tweet"
       end
     end
   end

--- a/app/models/maid.rb
+++ b/app/models/maid.rb
@@ -25,7 +25,7 @@ class Maid < ActiveRecord::Base
       begin
         maid = Maid.create(name: list[:name], floor: list[:floor], number: list[:number])
         if list[:screen_name]
-          TwitterAccount.create(uid: client.get_user_uid(list[:screen_name]), screen_name: list[:screen_name], maid_id: maid.id)
+          TwitterAccount.create(uid: client.user_uid(list[:screen_name]), screen_name: list[:screen_name], maid_id: maid.id)
         end
       rescue => e
         p e

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,4 +2,5 @@
 Maid.import_info_from_homepage
 
 #メイドさん全員のツイート情報を最小限だけ取得
-TwitterAccount.get_seed_tweets
+client = TwitterClient
+client.get_seed_tweets

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,5 @@
 #メイドさんの情報をDBに投入する
 Maid.import_info_from_homepage
+
+#メイドさん全員のツイート情報を最小限だけ取得
+TwitterAccount.get_seed_tweets

--- a/lib/tasks/tweet_scheduler.rake
+++ b/lib/tasks/tweet_scheduler.rake
@@ -1,6 +1,7 @@
 desc "This task is called by the Heroku scheduler add-on"
 task :import_recent_tweets => :environment do
   puts "Getting tweets..."
-  TwitterCrawler.import_recent_tweet
+  crawler = TwitterCrawler.new
+  crawler.import_recent_tweet
   puts "done."
 end

--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -6,10 +6,23 @@ class TwitterClient
       config.access_token        = Rails.application.secrets[:twitter_api_access_token]
       config.access_token_secret = Rails.application.secrets[:twitter_api_access_token_secret]
     end
+
+    @default_options = {exclude_replies: true, include_rts: false}
   end
 
   def get_recent_tweets(user)
-    @client.user_timeline(user.screen_name, {count: 200, exclude_replies: false, include_rts: false})
+    options = @default_options
+    if user.tweets.last
+      options[:since_id] = user.tweets.last.id.to_i
+    else
+      options[:count] = 1
+    end
+
+    begin
+      @client.user_timeline(user.screen_name, options)
+    rescue => e
+      p e
+    end
   end
 
   def get_seed_tweets

--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -17,11 +17,10 @@ class TwitterClient
 
     begin
       TwitterAccount.all.each do |account|
-        tweets = @client.user_timeline(account.screen_name, {count: 10})
+        tweets = @client.user_timeline(account.screen_name, {count: 1})
         tweets.each do |tweet|
           Tweet.create(twitter_account_id: account.id, text: tweet.text, status_id: tweet.id, published_at: tweet.created_at)
         end
-        sleep 5
       end
     rescue => e
       p e

--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -43,7 +43,7 @@ class TwitterClient
     response.empty? ? collection.flatten : collect_with_max_id(collection, response.last.id - 1, &block)
   end
 
-  def get_user_uid(screen_name)
+  def user_uid(screen_name)
     @client.user(screen_name).id.to_s
   end
 end

--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -15,17 +15,17 @@ class TwitterClient
   def get_seed_tweets
     p "Start getting tweets..."
 
-    begin
-      TwitterAccount.all.each do |account|
+    TwitterAccount.all.each do |account|
+      begin
         tweets = @client.user_timeline(account.screen_name, {count: 1})
         tweets.each do |tweet|
           Tweet.create(twitter_account_id: account.id, text: tweet.text, status_id: tweet.id, published_at: tweet.created_at)
         end
+      rescue => e
+        p account
+        p e
       end
-    rescue => e
-      p e
     end
-
     p "Done..."
   end
 


### PR DESCRIPTION
@gaoch  ref #40 
DBへのアクセスが上限を超えてしまっていため，一部のメイドさん(ID後半)のツイートが取得できないバグが発生していました．そのため以下のように修正を行い対応します

修正前→修正後
直近の200ツイートを取得→IDからDBにあるなかでの最新のツイートを判断し，それよりも新しいツイートを取得
リプライも取得→リプライは取得しない
1日1回ツイートを取得する→1日2回ツイートを取得する．(これはHerokuのほうの設定)

またこの修正に伴い，初期データをセットする際に，1ツイートだけ取得するようにもしました

確認お願いします！！