### PR TITLE
tweet検索時に設定すべきidを間違えていたので修正

### DIFF
--- a/lib/twitter_client.rb
+++ b/lib/twitter_client.rb
@@ -13,7 +13,7 @@ class TwitterClient
   def get_recent_tweets(user)
     options = @default_options
     if user.tweets.last
-      options[:since_id] = user.tweets.last.id.to_i
+      options[:since_id] = user.tweets.last.status_id.to_i
     else
       options[:count] = 1
     end


### PR DESCRIPTION
@gaoch ref #44 
昨日話していた「ツイートを正しく取得できていないメイドさんが’いる」ということの原因を調査していました．

その原因の1つとしてidに関するタイポを見つけたので修正しました
とりあえずこれがうまく取得できてない原因の1つだと思いますが，もしかしたら他にもあるかもしれないっす...その時は見つかり次第PRだします〜